### PR TITLE
Fix TTS model from 'tts-hd' to 'tts-1'

### DIFF
--- a/notebooks/chapter2/01_openai_introduction.ipynb
+++ b/notebooks/chapter2/01_openai_introduction.ipynb
@@ -529,7 +529,7 @@
    "source": [
     "audio_output_path = Path(\"output.mp3\")\n",
     "with client.audio.speech.with_streaming_response.create(\n",
-    "    model=\"tts-hd\",\n",
+    "    model=\"tts-1\",\n",
     "    voice=\"alloy\",\n",
     "    input=\"こんにちは。私は AI アシスタントです！\",\n",
     ") as response:\n",


### PR DESCRIPTION
'tts-hd'モデルは現在存在しなく、動作しなく、書籍では'tts-1'と記載されていたため。
'tts-hd'モデルがないことは下記を参考にした。
https://platform.openai.com/docs/api-reference/audio/createSpeech